### PR TITLE
Fix AR-loss sign in first term

### DIFF
--- a/corel/loss_functions.py
+++ b/corel/loss_functions.py
@@ -19,7 +19,7 @@ def arloss(attraction_tensor, repulsion_tensor, lam):
     # combine up everything to accumulate across the entire batch
     loss_attraction = attraction_tensor.sum()
     loss_repulsion = repulsion_tensor.sum()
-    arloss = (lam * loss_attraction) + ((1. - lam) * loss_repulsion)
+    arloss = -(lam * loss_attraction) + ((1. - lam) * loss_repulsion)
     return arloss / attraction_tensor.shape[0]
 
 


### PR DESCRIPTION
The function [`arloss`](https://github.com/kiankd/corel2019/blob/9791d8a8a1564a407e264fcd7d4fd653185cdd62/corel/loss_functions.py#L18-L23) diverges wrt the equation (1) reported on your [paper](https://arxiv.org/pdf/1812.07627.pdf). In particular, the `L_attract` term is missing the minus sign.